### PR TITLE
Vagrant, Travis and No Bucket Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+
+before_install: ./provision.sh
+
+install: pip install -r requirements.txt --use-mirrors
+
+script: make test

--- a/README.md
+++ b/README.md
@@ -110,3 +110,16 @@ class MyTest(unittest.TestCase):
         self.mock.stop()
 ```
 
+Development
+===========
+A `Vagrantfile` is provided for development:
+
+```bash
+# On the host OS
+vagrant up
+vagrant ssh
+
+# On the vagrant instance
+cd /vagrant
+make test
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+# Encoding: utf-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# http://docs.vagrantup.com/v2/
+Vagrant.configure('2') do |config|
+  config.vm.box = 'ubuntu/trusty64'
+  config.vm.hostname = 's3po'
+  config.ssh.forward_agent = true
+
+  config.vm.provision :shell, inline:
+    'echo \'Defaults env_keep += "SSH_AUTH_SOCK"\' > /etc/sudoers.d/ssh-auth-sock; ' +
+    'chmod 0440 /etc/sudoers.d/ssh-auth-sock'
+
+  config.vm.provision :shell, path: 'provision.sh', privileged: false
+end

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -e
+
+sudo apt-get install -y python-pip python-dev
+
+echo '[Credentials]
+aws_access_key_id = not-a-real-id
+aws_secret_access_key = not-a-real-key' | tee /home/vagrant/.boto
+
+(
+    cd /vagrant
+    sudo pip install -r requirements.txt
+)

--- a/provision.sh
+++ b/provision.sh
@@ -6,9 +6,11 @@ sudo apt-get install -y python-pip python-dev
 
 echo '[Credentials]
 aws_access_key_id = not-a-real-id
-aws_secret_access_key = not-a-real-key' | tee /home/vagrant/.boto
+aws_secret_access_key = not-a-real-key' | tee ~/.boto
 
 (
-    cd /vagrant
-    sudo pip install -r requirements.txt
+    if [ -z $TRAVIS ]; then
+        cd /vagrant
+        sudo pip install -r requirements.txt
+    fi
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+boto==2.36.0
+coverage==3.7.1
+gevent==1.0.1
+nose==1.3.4

--- a/s3po/connection.py
+++ b/s3po/connection.py
@@ -31,7 +31,7 @@ class Connection(object):
 
     def _download(self, bucket, key, fobj, retries):
         '''Download the contents of bucket/key to fobj'''
-        bucket = self.conn.get_bucket(bucket)
+        bucket = self.conn.get_bucket(bucket, validate=False)
         # Make a file that we'll write into
         fobj = CountFile(fobj)
         obj = bucket.get_key(key)
@@ -60,7 +60,7 @@ class Connection(object):
         '''Upload the contents of fobj to bucket/key with headers'''
         # Make our headers object
         headers = headers or {}
-        bucket = self.conn.get_bucket(bucket)
+        bucket = self.conn.get_bucket(bucket, validate=False)
         # We'll read in some data, and if the file appears small enough, we'll
         # upload it in a single go. In order for it to be a valid multipart
         # upload, it needs at least two parts, so we will make sure there are

--- a/s3po/mock/connection.py
+++ b/s3po/mock/connection.py
@@ -22,7 +22,7 @@ class S3Connection(object):
             raise S3ResponseError('Bucket %s not empty' % bucket)
         self._buckets.pop(bucket, None)
 
-    def get_bucket(self, bucket):
+    def get_bucket(self, bucket, validate=False):
         '''Get a bucket'''
         obj = self._buckets.get(bucket)
         if not obj:

--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-try:
-    from setuptools import setup
-    extra = {
-        'install_requires' : ['boto', 'gevent']
-    }
-except ImportError:
-    from distutils.core import setup
-    extra = {
-        'dependencies' : ['boto', 'gevent']
-    }
+from setuptools import setup
 
 setup(
     name             = 's3po',
@@ -45,6 +36,12 @@ setup(
     packages         = ['s3po', 's3po.mock'],
     license          = 'MIT',
     platforms        = 'Posix; MacOS X',
+    install_requires = [
+        'boto',
+        'coverage',
+        'gevent',
+        'nose'
+    ]
     classifiers      = [
         'License :: OSI Approved :: MIT License',
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 setup(
     name             = 's3po',
-    version          = '0.3.1',
+    version          = '0.3.2',
     description      = 'An uploading daemon for S3',
     long_description = '''Boto is a wonderful library. This is just a little
         help for dealing with multipart uploads, batch uploading with gevent


### PR DESCRIPTION
We found that every download request also was `HEAD`-ing the bucket, which seems unnecessary.

This is fallout from an operational issue where clients were receiving a large number of `Bad Request` responses from Swift servers when trying to download objects.