### PR TITLE
Add bucket listing ability

### DIFF
--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -28,8 +28,8 @@ class Memory(object):
         '''List the contents of a bucket.'''
         if prefix is None:
             prefix = ''
-        keys = [key for key in self.buckets[bucket].keys() if key.startswith(prefix)]
+        keys = (key for key in self.buckets[bucket].keys() if key.startswith(prefix))
         if delimiter:
-            return list(set(key.split(delimiter, 1)[0] for key in keys))
+            return (prefix for prefix in set(key.split(delimiter, 1)[0] for key in keys))
         else:
             return keys

--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -24,7 +24,7 @@ class Memory(object):
 
         self.buckets[bucket][key] = fobj.read()
 
-    def list(self, bucket, prefix, delimiter, headers=None):
+    def list(self, bucket, prefix=None, delimiter=None, headers=None):
         '''List the contents of a bucket.'''
         if prefix is None:
             prefix = ''

--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -23,3 +23,13 @@ class Memory(object):
             self.buckets[bucket] = {}
 
         self.buckets[bucket][key] = fobj.read()
+
+    def list(self, bucket, prefix, delimiter, headers=None):
+        '''List the contents of a bucket.'''
+        if prefix is None:
+            prefix = ''
+        keys = [key for key in self.buckets[bucket].keys() if key.startswith(prefix)]
+        if delimiter:
+            return list(set(key.split(delimiter, 1)[0] for key in keys))
+        else:
+            return keys

--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -24,7 +24,7 @@ class Memory(object):
 
         self.buckets[bucket][key] = fobj.read()
 
-    def list(self, bucket, prefix=None, delimiter=None, headers=None):
+    def list(self, bucket, prefix=None, delimiter=None, retries=None, headers=None):
         '''List the contents of a bucket.'''
         if prefix is None:
             prefix = ''

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -94,8 +94,15 @@ class S3(object):
             multi.complete_upload()
             return True
 
-    def list(self, bucket, prefix=None, delimiter=None, headers=None):
+    def _list_retry(self, retries, bucket, *args, **kwargs):
+        @retry(retries)
+        def func():
+            return bucket.list(*args, **kwargs)
+        return func()
+
+    def list(self, bucket, prefix=None, delimiter=None, retries=3, headers=None):
         '''List the bucket, possibly limiting the search with a prefix.'''
         bucket = self.conn.get_bucket(bucket)
         # consume iterator to make a list to keep parity with Swift backend
-        return (key.name for key in bucket.list(prefix, delimiter, headers=headers))
+        return (key.name for key in self._list_retry(retries, bucket,
+                                          prefix, delimiter, headers=headers))

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -93,3 +93,13 @@ class S3(object):
             multi.upload_part_from_file(StringIO(data), count)
             multi.complete_upload()
             return True
+
+    def list(self, bucket, prefix=None, delimiter=None, headers=None):
+        '''List the bucket, possibly limiting the search with a prefix.'''
+        bucket = self.conn.get_bucket(bucket)
+        if prefix is None:
+            prefix = ''
+        if delimiter is None:
+            delimiteer = ''
+        # Consumer iterator to make a list to keep parity with Swift backend
+        return list(bucket.list(prefix, delimiter, headers=headers))

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -100,6 +100,6 @@ class S3(object):
         if prefix is None:
             prefix = ''
         if delimiter is None:
-            delimiteer = ''
+            delimiter = ''
         # Consumer iterator to make a list to keep parity with Swift backend
         return list(bucket.list(prefix, delimiter, headers=headers))

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -98,5 +98,4 @@ class S3(object):
         '''List the bucket, possibly limiting the search with a prefix.'''
         bucket = self.conn.get_bucket(bucket)
         # consume iterator to make a list to keep parity with Swift backend
-        results = list(bucket.list(prefix, delimiter, headers=headers))
-        return [result.name for result in results]
+        return (key.name for key in bucket.list(prefix, delimiter, headers=headers))

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -97,9 +97,6 @@ class S3(object):
     def list(self, bucket, prefix=None, delimiter=None, headers=None):
         '''List the bucket, possibly limiting the search with a prefix.'''
         bucket = self.conn.get_bucket(bucket)
-        if prefix is None:
-            prefix = ''
-        if delimiter is None:
-            delimiter = ''
-        # Consumer iterator to make a list to keep parity with Swift backend
-        return list(bucket.list(prefix, delimiter, headers=headers))
+        # consume iterator to make a list to keep parity with Swift backend
+        results = list(bucket.list(prefix, delimiter, headers=headers))
+        return [result.name for result in results]

--- a/s3po/backends/swift.py
+++ b/s3po/backends/swift.py
@@ -65,10 +65,18 @@ class Swift(object):
 
         func()
 
-    def list(self, bucket, prefix=None, delimiter=None, headers=None,
-                   chunksize=100):
+    def _get_container_retry(self, retries, *args, **kwargs):
+        '''Wrap Swift's get_container with retries.'''
+        @retry(retries)
+        def func():
+            return self.conn.get_container(*args, **kwargs)
+        return func()
+
+    def list(self, bucket, prefix=None, delimiter=None, retries=3,
+                   headers=None, chunksize=100):
         '''List the bucket, possibly limiting the search with a prefix.'''
-        listing =  self.conn.get_container(bucket,
+        listing =  self._get_container_retry(retries,
+                                           bucket,
                                            prefix=prefix,
                                            delimiter=delimiter,
                                            limit=chunksize)[1]

--- a/s3po/backends/swift.py
+++ b/s3po/backends/swift.py
@@ -67,11 +67,7 @@ class Swift(object):
 
     def list(self, bucket, prefix=None, delimiter=None, headers=None):
         '''List the bucket, possibly limiting the search with a prefix.'''
-        if prefix is None:
-            prefix = ''
-        if delimiter is None:
-            delimiter = ''
-        # Consumer iterator to make a list to keep parity with Swift backend
-        return self.conn.get_container(bucket, 
-                                       prefix=prefix, 
-                                       delimiter=delimiter)[1]
+        results =  self.conn.get_container(bucket, 
+                                           prefix=prefix, 
+                                           delimiter=delimiter)[1]
+        return [result['name'] for result in results]

--- a/s3po/backends/swift.py
+++ b/s3po/backends/swift.py
@@ -70,4 +70,5 @@ class Swift(object):
         results =  self.conn.get_container(bucket, 
                                            prefix=prefix, 
                                            delimiter=delimiter)[1]
-        return [result['name'] for result in results]
+        # returns a generator like other backends
+        return (result['name'] for result in results)

--- a/s3po/backends/swift.py
+++ b/s3po/backends/swift.py
@@ -64,3 +64,14 @@ class Swift(object):
                 raise UploadException('Failed to upload %s' % key)
 
         func()
+
+    def list(self, bucket, prefix=None, delimiter=None, headers=None):
+        '''List the bucket, possibly limiting the search with a prefix.'''
+        if prefix is None:
+            prefix = ''
+        if delimiter is None:
+            delimiter = ''
+        # Consumer iterator to make a list to keep parity with Swift backend
+        return self.conn.get_container(bucket, 
+                                       prefix=prefix, 
+                                       delimiter=delimiter)[1]

--- a/s3po/connection.py
+++ b/s3po/connection.py
@@ -77,3 +77,7 @@ class Connection(object):
         the right context management'''
         with open(os.path.abspath(path), mode) as fout:
             return self.download(bucket, key, fout, retries)
+
+    def list(self, bucket, prefix=None, delimiter=None, headers=None):
+        '''List the contents of the bucket, optionally specifying a prefix.'''
+        return self.backend.list(bucket, prefix, delimiter, headers)

--- a/s3po/connection.py
+++ b/s3po/connection.py
@@ -78,6 +78,6 @@ class Connection(object):
         with open(os.path.abspath(path), mode) as fout:
             return self.download(bucket, key, fout, retries)
 
-    def list(self, bucket, prefix=None, delimiter=None, headers=None):
+    def list(self, bucket, prefix=None, delimiter=None, retries=3, headers=None):
         '''List the contents of the bucket, optionally specifying a prefix.'''
-        return self.backend.list(bucket, prefix, delimiter, headers)
+        return self.backend.list(bucket, prefix, delimiter, retries, headers)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 setup(
     name             = 's3po',
-    version          = '0.4.0',
+    version          = '0.4.1',
     description      = 'An uploading daemon for S3',
     long_description = '''Boto is a wonderful library. This is just a little
         help for dealing with multipart uploads, batch uploading with gevent

--- a/test/test_backends/test_s3.py
+++ b/test/test_backends/test_s3.py
@@ -3,6 +3,8 @@
 from cStringIO import StringIO
 
 import mock
+from collections import namedtuple
+
 from base import BaseTest
 
 from s3po.backends.s3 import S3
@@ -88,7 +90,9 @@ class Bucket(object):
         return self.keys[key]
 
     def list(self, prefix, delimiter, headers=None):
-        return [key for key in self.keys if key.startswith(prefix)]
+        prefix = prefix or ''
+        Key = namedtuple('Key', ['name'])
+        return [Key(key) for key in self.keys if key.startswith(prefix)]
 
     def initiate_multipart_upload(self, key, headers=None):
         return Multi(self, key, headers)

--- a/test/test_backends/test_s3.py
+++ b/test/test_backends/test_s3.py
@@ -62,7 +62,7 @@ class S3BackendTest(BaseTest):
         '''Can list a bucket'''
         self.bucket.new_key('key')
         with mock.patch.object(self.backend.conn, 'get_bucket', return_value=self.bucket):
-            self.assertEqual(self.backend.list('bucket'),
+            self.assertEqual(list(self.backend.list('bucket')),
                              ['key'])
 
     def test_list_prefix(self):
@@ -70,7 +70,7 @@ class S3BackendTest(BaseTest):
         self.bucket.new_key('key')
         self.bucket.new_key('starts_with_something_else')
         with mock.patch.object(self.backend.conn, 'get_bucket', return_value=self.bucket):
-            self.assertEqual(self.backend.list('bucket', prefix='k'),
+            self.assertEqual(list(self.backend.list('bucket', prefix='k')),
                              ['key'])
 
 

--- a/test/test_backends/test_swift.py
+++ b/test/test_backends/test_swift.py
@@ -62,6 +62,7 @@ class SwiftBackendTest(BaseTest):
             self.backend.upload, 'bucket', 'key', StringIO('content'), 1)
 
     def test_list(self):
-        self.conn.get_container.return_value = (None, [{'name':'key'}])
+        self.conn.get_container.side_effect = [(None, [{'name':'key'}]),
+                                               (None, [])]
         self.assertEqual(list(self.backend.list('bucket')),
                          ['key'])

--- a/test/test_backends/test_swift.py
+++ b/test/test_backends/test_swift.py
@@ -63,5 +63,5 @@ class SwiftBackendTest(BaseTest):
 
     def test_list(self):
         self.conn.get_container.return_value = (None, [{'name':'key'}])
-        self.assertEqual(self.backend.list('bucket'),
+        self.assertEqual(list(self.backend.list('bucket')),
                          ['key'])

--- a/test/test_backends/test_swift.py
+++ b/test/test_backends/test_swift.py
@@ -60,3 +60,8 @@ class SwiftBackendTest(BaseTest):
         self.conn.put_object.side_effect = ClientException('Failed to upload')
         self.assertRaises(UploadException,
             self.backend.upload, 'bucket', 'key', StringIO('content'), 1)
+
+    def test_list(self):
+        self.conn.get_container.return_value = (None, ['key'])
+        self.assertEqual(self.backend.list('bucket'),
+                         ['key'])

--- a/test/test_backends/test_swift.py
+++ b/test/test_backends/test_swift.py
@@ -62,6 +62,6 @@ class SwiftBackendTest(BaseTest):
             self.backend.upload, 'bucket', 'key', StringIO('content'), 1)
 
     def test_list(self):
-        self.conn.get_container.return_value = (None, ['key'])
+        self.conn.get_container.return_value = (None, [{'name':'key'}])
         self.assertEqual(self.backend.list('bucket'),
                          ['key'])

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -61,18 +61,18 @@ class ConnectionTest(BaseTest):
 
     def test_list(self):
         self.conn.upload('bucket', 'key', StringIO('content'))
-        self.assertEqual(self.conn.list('bucket'), 
+        self.assertEqual(list(self.conn.list('bucket')), 
                          ['key'])
 
     def test_list_prefix(self):
         self.conn.upload('bucket', 'key', StringIO('content'))
         self.conn.upload('bucket', 'something_else', StringIO('content'))
-        self.assertEqual(self.conn.list('bucket', prefix='k'), 
+        self.assertEqual(list(self.conn.list('bucket', prefix='k')), 
                          ['key'])
 
     def test_list_delimiter(self):
         self.conn.upload('bucket', 'a.1', StringIO('content'))
         self.conn.upload('bucket', 'a.2', StringIO('content'))
-        self.assertEqual(self.conn.list('bucket', delimiter='.'), 
+        self.assertEqual(list(self.conn.list('bucket', delimiter='.')), 
                          ['a'])
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -58,3 +58,21 @@ class ConnectionTest(BaseTest):
             pass
 
         self.assertEqual(original, self.conn.backend)
+
+    def test_list(self):
+        self.conn.upload('bucket', 'key', StringIO('content'))
+        self.assertEqual(self.conn.list('bucket'), 
+                         ['key'])
+
+    def test_list_prefix(self):
+        self.conn.upload('bucket', 'key', StringIO('content'))
+        self.conn.upload('bucket', 'something_else', StringIO('content'))
+        self.assertEqual(self.conn.list('bucket', prefix='k'), 
+                         ['key'])
+
+    def test_list_delimiter(self):
+        self.conn.upload('bucket', 'a.1', StringIO('content'))
+        self.conn.upload('bucket', 'a.2', StringIO('content'))
+        self.assertEqual(self.conn.list('bucket', delimiter='.'), 
+                         ['a'])
+


### PR DESCRIPTION
This adds the ability to list buckets in both Swift and S3.  The returned objects aren't identical and I didn't abstract that away, but they have matching functionality.

@dlecocq 