### PR TITLE
Do not validate objects when downloading them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 setup(
     name             = 's3po',
-    version          = '0.4.4',
+    version          = '0.4.5',
     description      = 'An uploading daemon for S3',
     long_description = '''Boto is a wonderful library. This is just a little
         help for dealing with multipart uploads, batch uploading with gevent


### PR DESCRIPTION
By default `boto` performs an unnecessary `HEAD` request for every `GET`. The `validate=False` argument disables that feature.