### PR TITLE
Pass on Swift exception message to our DownloadException

### DIFF
--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -13,7 +13,7 @@ class Memory(object):
         '''Download the contents of bucket/key to fobj'''
         obj = self.buckets.get(bucket, {}).get(key)
         if not obj:
-            raise DownloadException('%s / %s not fount' % (bucket, key))
+            raise DownloadException('%s / %s not found' % (bucket, key))
         else:
             fobj.write(obj)
 

--- a/s3po/backends/swift.py
+++ b/s3po/backends/swift.py
@@ -43,8 +43,8 @@ class Swift(object):
                     raise DownloadException('Downloaded only %i of %i bytes' % (
                         fobj.count, int(length)))
 
-            except ClientException:
-                raise DownloadException('Key not found.')
+            except ClientException as exc:
+                raise DownloadException('Key not found: ' + str(exc))
 
         # Invoke the download
         func()

--- a/test/test_backends/test_swift.py
+++ b/test/test_backends/test_swift.py
@@ -22,8 +22,10 @@ class SwiftBackendTest(BaseTest):
     def test_download_missing(self):
         '''Downloading a missing object gives us failure.'''
         self.conn.get_object.side_effect = ClientException('Missing')
-        self.assertRaises(
-            DownloadException, self.backend.download, 'bucket', 'key', StringIO(), 1)
+        with self.assertRaises(DownloadException) as manager:
+            self.backend.download('bucket', 'key', StringIO(), 1)
+        the_exception = manager.exception
+        self.assertIn('Missing', str(the_exception))
 
     def test_download_success(self):
         '''Can successfully download an object.'''


### PR DESCRIPTION
Instead of swallowing the Swift `ClientException` completely, append its message onto the message of our `DownloadException`.