### PR TITLE
Use retries on all container listings

### DIFF
--- a/s3po/backends/swift.py
+++ b/s3po/backends/swift.py
@@ -84,7 +84,8 @@ class Swift(object):
                 yield result['name']
             # out of results in current listing, get more starting at the end
             marker = listing[-1]['name']
-            listing = self.conn.get_container(bucket,
+            listing = self._get_container_retry(retries,
+                                              bucket,
                                               prefix=prefix,
                                               delimiter=delimiter,
                                               marker=marker,


### PR DESCRIPTION
Listing in swift requires trying the list command again to get more results if necessary. There was a bug where for subsequent `get_container` calls to swift we were not using the appropriate retry logic.

This change fixed at least one persistent failure in Custos.

@dlecocq 