### PR TITLE
Use virtualbox provider by default.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 # http://docs.vagrantup.com/v2/
 Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/trusty64'


### PR DESCRIPTION
The `ubuntu/trusty64` image doesn't work with other providers.

This will prefer using virtualbox even if you have vmware installed locally on your machine.