### PR TITLE
Fix Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
+dist: trusty
 sudo: false
 language: python
 python:
   - "2.7"
-
 before_install: ./scripts/ci/provision.sh
-
-install: pip install -r requirements.txt --use-mirrors
-
 script: make test


### PR DESCRIPTION
The [default `install` task](https://docs.travis-ci.com/user/languages/python/) is `pip install -r requirements.txt`, and Travis doesn't appear to like the `--use-mirrors` option