### PR TITLE
Simplify vagrant provisioning and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,5 @@ vagrant up
 vagrant ssh
 
 # On the vagrant instance
-cd /vagrant
 make test
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,9 +10,5 @@ Vagrant.configure('2') do |config|
   config.vm.hostname = 's3po'
   config.ssh.forward_agent = true
 
-  config.vm.provision :shell, inline:
-    'echo \'Defaults env_keep += "SSH_AUTH_SOCK"\' > /etc/sudoers.d/ssh-auth-sock; ' +
-    'chmod 0440 /etc/sudoers.d/ssh-auth-sock'
-
   config.vm.provision :shell, path: 'scripts/vagrant/provision.sh', privileged: false
 end

--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -12,3 +12,5 @@ aws_secret_access_key = not-a-real-key' > ~/.boto
     cd /vagrant
     sudo pip install -r requirements.txt
 )
+
+echo $'\ncd /vagrant' >> ~/.profile


### PR DESCRIPTION
Drop unnecessary hack for SSH forwarding. This is only required if the provisioning needs access to private repos, but this is a public repository, so it clearly has no private dependencies.

Automatically change to `/vagrant` on login. This avoids requiring manual steps after every `vagrant ssh`.