### PR TITLE
Switch to Boto3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto==2.36.0
+boto3==1.4.8
 coverage==3.7.1
 gevent==1.0.1
 mock==1.3.0

--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -19,7 +19,7 @@ class Memory(object):
         else:
             fobj.write(obj)
 
-    def upload(self, bucket, key, fobj, retries, headers=None):
+    def upload(self, bucket, key, fobj, retries, headers=None, extra=None):
         '''Upload the contents of fobj to bucket/key with headers'''
         self.buckets[bucket][key] = fobj.read()
 

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -12,10 +12,10 @@ from ..exceptions import DeleteException, DownloadException, UploadException
 
 class S3(object):
     '''Our connection to S3'''
-    # How big must a file get before it's multiparted. Also how big the chunks
-    # are that we'll read
-    chunk_size = 50 * 1024 * 1204
-    min_chunk_size = 5 * 1024 * 1024
+    # How big must a file get before it's multiparted.
+    multipart_threshold = 5 * 1024 * 1204 * 1024
+    # Size of chunks for multipart uploads
+    multipart_chunk_size = 50 * 1024 * 1204
 
     def __init__(self, *args, **kwargs):
         self.conn = boto3.resource('s3', *args, **kwargs)
@@ -29,8 +29,8 @@ class S3(object):
 
         key = bucket.Object(key)
         config = TransferConfig(
-            multipart_threshold=(2 * self.chunk_size),
-            multipart_chunksize=self.chunk_size,
+            multipart_threshold=self.multipart_threshold,
+            multipart_chunksize=self.multipart_chunk_size,
             use_threads=False,
             num_download_attempts=retries)
 
@@ -45,8 +45,8 @@ class S3(object):
 
         key = bucket.Object(key)
         config = TransferConfig(
-            multipart_threshold=(2 * self.chunk_size),
-            multipart_chunksize=self.chunk_size,
+            multipart_threshold=self.multipart_threshold,
+            multipart_chunksize=self.multipart_chunk_size,
             use_threads=False,
             num_download_attempts=retries)
         try:

--- a/s3po/backends/s3.py
+++ b/s3po/backends/s3.py
@@ -1,12 +1,13 @@
 '''Deal with S3.'''
 
 
-from boto.s3.connection import S3Connection
-from boto.exception import S3ResponseError, BotoServerError, BotoClientError
-from cStringIO import StringIO
+import boto3
+from boto3.s3.transfer import TransferConfig
+from boto3.exceptions import Boto3Error
+from botocore.exceptions import BotoCoreError, ClientError
 
-from ..util import CountFile, retry, logger
-from ..exceptions import UploadException, DownloadException, DeleteException
+from ..util import retry
+from ..exceptions import DeleteException, DownloadException, UploadException
 
 
 class S3(object):
@@ -17,111 +18,78 @@ class S3(object):
     min_chunk_size = 5 * 1024 * 1024
 
     def __init__(self, *args, **kwargs):
-        self.conn = S3Connection(*args, **kwargs)
+        self.conn = boto3.resource('s3', *args, **kwargs)
 
     def get_bucket(self, bucket):
-        return self.conn.get_bucket(bucket, validate=False)
+        return self.conn.Bucket(bucket)
 
-    def download(self, bucket, key, destination, retries, headers=None):
+    def download(self, bucket, key, destination, retries, extra=None):
         '''Download the contents of bucket/key to destination'''
         bucket = self.get_bucket(bucket)
-        # Make a file that we'll write into
-        destination = CountFile(destination)
-        obj = bucket.get_key(key, validate=False)
 
-        # Get its original location so we can go back to it if need be
-        offset = destination.tell()
+        key = bucket.Object(key)
+        config = TransferConfig(
+            multipart_threshold=(2 * self.chunk_size),
+            multipart_chunksize=self.chunk_size,
+            use_threads=False,
+            num_download_attempts=retries)
 
-        @retry(retries)
-        def func():
-            '''The bit that we want to retry'''
-            destination.seek(offset)
-            try:
-                obj.get_contents_to_file(destination, headers=headers)
-            except S3ResponseError as exc:
-                raise DownloadException('Failed to download: %s' % exc.message)
-            # Ensure it was downloaded completely
-            logger.info(
-                'Downloaded %s bytes out of %s' % (destination.count, obj.size))
-            if obj.size != destination.count:
-                raise DownloadException('Downloaded only %i of %i bytes' % (
-                    destination.count, obj.size or 0))
-        # With our wrapped function defined, we'll go ahead an invoke it.
-        func()
+        try:
+            key.download_fileobj(destination, Config=config, ExtraArgs=extra)
+        except (ClientError, BotoCoreError, Boto3Error) as exc:
+            raise DownloadException('Failed to download: %s' % exc.message)
 
-    def upload(self, bucket, key, source, retries, headers=None):
-        '''Upload the contents of source to bucket/key with headers'''
-        # Make our headers object
-        headers = headers or {}
+    def upload(self, bucket, key, source, retries, extra=None):
+        '''Upload the contents of source to bucket/key'''
         bucket = self.get_bucket(bucket)
-        # We'll read in some data, and if the file appears small enough, we'll
-        # upload it in a single go. In order for it to be a valid multipart
-        # upload, it needs at least two parts, so we will make sure there are
-        # at least enough for two parts before we commit to multipart
-        data = source.read(2 * self.chunk_size)
-        if len(data) < (2 * self.chunk_size):
-            key = bucket.new_key(key)
 
-            @retry(retries)
-            def func():
-                '''The bit that we want to retry'''
-                key.set_contents_from_string(data, headers=headers)
-                if key.size != len(data):
-                    raise UploadException('Uploaded only %i for %i bytes' % (
-                        key.size, len(data)))
-                return True
-            return func()
-        else:
-            logger.info('Performing multipart upload')
-            # Otherwise, it's a large-enough file that we should multipart
-            # upload it. There's a restriction that all parts of a multipart
-            # upload must be at least 5MB. Therefore, we should keep uploading
-            # chunks as long as the remaining data is 5MB greater than our chunk
-            # size. That way we avoid the case where we have a remainder less
-            # than this limit
-            multi = bucket.initiate_multipart_upload(key, headers=headers)
-            count = 1
-            while len(data) >= (self.chunk_size + self.min_chunk_size):
-                logger.info('Uploading chunk %s', count)
-                part = data[0:self.chunk_size]
-                retry(
-                    retries)(multi.upload_part_from_file)(StringIO(part), count)
-                data = (
-                    data[self.chunk_size:] +
-                    source.read(self.chunk_size))
-                count += 1
-            # And finally, the last part
-            multi.upload_part_from_file(StringIO(data), count)
-            multi.complete_upload()
+        key = bucket.Object(key)
+        config = TransferConfig(
+            multipart_threshold=(2 * self.chunk_size),
+            multipart_chunksize=self.chunk_size,
+            use_threads=False,
+            num_download_attempts=retries)
+        try:
+            key.upload_fileobj(source, Config=config, ExtraArgs=extra)
             return True
+        except (ClientError, BotoCoreError, Boto3Error) as ex:
+            raise UploadException('Failed to upload s3://{}/{}: {}'.format(
+                bucket, key, ex.message))
 
-    def _list_retry(self, retries, bucket, *args, **kwargs):
+    def _list_retry(self, retries, bucket, **kwargs):
         @retry(retries)
         def func():
-            return bucket.list(*args, **kwargs)
+            return bucket.objects.filter(**kwargs)
         return func()
 
-    def list(self, bucket, prefix=None, delimiter=None, retries=3, headers=None):
+    def list(self, bucket, prefix=None, delimiter=None, retries=3, extra=None):
         '''List the bucket, possibly limiting the search with a prefix.'''
-        bucket = self.conn.get_bucket(bucket)
-        # consume iterator to make a list to keep parity with Swift backend
-        return (key.name for key in self._list_retry(retries, bucket,
-                                          prefix, delimiter, headers=headers))
-
-    def delete(self, bucket, key, retries, headers=None):
-        '''Delete bucket/key with headers'''
-        # Make our headers object
-        headers = headers or {}
         bucket = self.get_bucket(bucket)
-        key = bucket.new_key(key)
+        opts = {}
+        if prefix:
+            opts['Prefix'] = prefix
+        if delimiter:
+            opts['Delimiter'] = delimiter
+        if extra:
+            opts['ExtraArgs'] = extra
+        # consume iterator to make a list to keep parity with Swift backend
+        return (
+            key.key for key in self._list_retry(retries, bucket, **opts)
+        )
+
+    def delete(self, bucket, key, retries):
+        '''Delete bucket/key'''
+        bucket = self.get_bucket(bucket)
+        key = bucket.Object(key)
 
         @retry(retries)
         def func():
             '''The bit that we want to retry'''
             try:
-                key.delete(headers=headers)
-            except (BotoServerError, BotoClientError) as exc:
-                raise DeleteException('Failed to delete %s/%s: %s(%s)' %
+                key.delete()
+            except (ClientError, BotoCoreError, Boto3Error) as exc:
+                raise DeleteException(
+                    'Failed to delete %s/%s: %s(%s)' %
                     (bucket, key, exc.__class__.__name__, exc.message))
 
         return func()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 setup(
     name='s3po',
-    version='0.4.7',
+    version='0.5.0',
     description='An uploading daemon for S3',
     long_description='''Boto is a wonderful library. This is just a little
         help for dealing with multipart uploads, batch uploading with gevent
@@ -37,7 +37,7 @@ setup(
     license='MIT',
     platforms='Posix; MacOS X',
     install_requires=[
-        'boto',
+        'boto3',
         'coverage',
         'gevent',
         'mock',

--- a/test/test_backends/test_s3.py
+++ b/test/test_backends/test_s3.py
@@ -1,12 +1,11 @@
 '''Talk to S3'''
 
 from cStringIO import StringIO
-from boto.exception import S3ResponseError
+from botocore.exceptions import BotoCoreError, ClientError
 
 import mock
-from collections import namedtuple
 
-from base import BaseTest
+from test.base import BaseTest
 
 from s3po.backends.s3 import S3
 from s3po.exceptions import UploadException, DownloadException, DeleteException
@@ -18,8 +17,14 @@ class S3BackendTest(BaseTest):
     def setUp(self):
         BaseTest.setUp(self)
         self.bucket = Bucket('bucket')
-        self.backend = S3(aws_access_key_id='not', aws_secret_access_key='a real key')
-        mock.patch.object(self.backend, 'get_bucket', return_value=self.bucket).start()
+        self.backend = S3(
+            aws_access_key_id='not', aws_secret_access_key='a real key')
+        self.bucket_patcher = mock.patch.object(
+            self.backend.conn, 'Bucket', return_value=self.bucket)
+        self.bucket_patcher.start()
+
+    def tearDown(self):
+        self.bucket_patcher.stop()
 
     def test_round_trip(self):
         '''Can round-trip an object.'''
@@ -30,24 +35,23 @@ class S3BackendTest(BaseTest):
 
     def test_download_missing(self):
         '''Downloading a missing object gives us failure.'''
-        key = self.bucket.get_key('key')
-        exception = S3ResponseError(404, 'Not Found')
-        with mock.patch.object(key, 'get_contents_to_file', side_effect=exception):
-            self.assertRaises(
-                DownloadException, self.backend.download, 'bucket', 'key', StringIO(), 1)
+        key = self.bucket.Object('key')
+        error = ClientError(
+            {'Error': {'Message': 'Not Found', 'Code': '404'}},
+            'HeadObject'
+        )
+        with mock.patch.object(key, 'download_fileobj', side_effect=error):
+            with self.assertRaises(DownloadException):
+                self.backend.download('bucket', 'key', StringIO(), 1)
 
-    def test_download_size_mismatch(self):
-        '''If we've downloaded less than expected, throws an exception.'''
-        self.backend.upload('bucket', 'key', StringIO('content'), 1)
-        key = self.bucket.get_key('key')
-        with mock.patch.object(key, 'get_contents_to_file'):
-            self.assertRaises(
-                DownloadException, self.backend.download, 'bucket', 'key', StringIO(), 1)
-
-    def test_upload_partial(self):
-        '''Throws an exception if we only partially upload'''
-        key = self.bucket.new_key('key')
-        with mock.patch.object(key, 'set_contents_from_string'):
+    def test_upload_exception(self):
+        '''Throws an upload exception if an error occured during upload'''
+        key = self.bucket.Object('key')
+        error = ClientError(
+            {'Error': {'Message': 'Service Unavailable', 'Code': '503'}},
+            'PutObject'
+        )
+        with mock.patch.object(key, 'upload_fileobj', side_effect=error):
             self.assertRaises(
                 UploadException,
                 self.backend.upload, 'bucket', 'key', StringIO('content'), 1)
@@ -64,36 +68,29 @@ class S3BackendTest(BaseTest):
 
     def test_list(self):
         '''Can list a bucket'''
-        self.bucket.new_key('key')
-        with mock.patch.object(self.backend.conn, 'get_bucket', return_value=self.bucket):
-            self.assertEqual(list(self.backend.list('bucket')),
-                             ['key'])
+        self.bucket.Object('abc')
+        self.assertEqual(list(self.backend.list('bucket')), ['abc'])
 
     def test_list_prefix(self):
         '''Can list a bucket limited by prefix'''
-        self.bucket.new_key('key')
-        self.bucket.new_key('starts_with_something_else')
-        with mock.patch.object(self.backend.conn, 'get_bucket', return_value=self.bucket):
-            self.assertEqual(list(self.backend.list('bucket', prefix='k')),
-                             ['key'])
-
+        self.bucket.Object('abc')
+        self.bucket.Object('starts_with_something_else')
+        self.assertEqual(list(self.backend.list('bucket', prefix='a')),
+                         ['abc'])
 
     def test_delete(self):
         '''Can delete a key'''
-        self.bucket.new_key('key')
-        with mock.patch.object(self.backend.conn, 'get_bucket', return_value=self.bucket):
-            self.backend.delete('bucket', 'key', 1)
-            self.assertEqual(list(self.backend.list('bucket', prefix='k')),
-                             [])
+        self.bucket.Object('abc')
+        self.backend.delete('bucket', 'abc', 1)
+        self.assertEqual(list(self.backend.list('bucket', prefix='a')), [])
 
     def test_deletion_error(self):
         '''Raises DeleteException on key.delete() error'''
-        key = self.bucket.new_key('key')
-        exception = S3ResponseError(404, 'Not Found')
-        with mock.patch.object(self.backend.conn, 'get_bucket', return_value=self.bucket):
-            with mock.patch.object(key, 'delete', side_effect=exception):
-                with self.assertRaises(DeleteException):
-                    self.backend.delete('bucket', 'key', 1)
+        key = self.bucket.Object('key')
+        error = BotoCoreError()
+        with mock.patch.object(key, 'delete', side_effect=error):
+            with self.assertRaises(DeleteException):
+                self.backend.delete('bucket', 'key', 1)
 
 
 class Bucket(object):
@@ -103,61 +100,55 @@ class Bucket(object):
         self.name = name
         self.keys = {}
 
-    def get_key(self, key, validate=True):
-        return self.keys.get(key) or self.new_key(key)
+        class Filterable(object):
+            '''Provides the filter method on the objects field'''
+            def __init__(self, bucket):
+                self.bucket = bucket
 
-    def new_key(self, key):
-        if key not in self.keys:
-            self.keys[key] = Key(self, key)
-        return self.keys[key]
+            def filter(self, Prefix=None, Delimiter=None, ExtraArgs=None):
+                prefix = Prefix or ''
+
+                class Item(object):
+                    '''Provides the Object method for mock list results'''
+                    def __init__(self, bucket, key):
+                        self.bucket = bucket
+                        self.key = key
+
+                    def Object(self):
+                        return self.bucket.Object(key)
+
+                return [
+                    Item(self.bucket, key) for key in self.bucket.keys
+                    if key.startswith(prefix)
+                ]
+
+        self.objects = Filterable(self)
+
+    def Object(self, key):
+        return self._new_key(key)
+
+    def _new_key(self, key):
+        new_key = self.keys.get(key)
+        if not new_key:
+            new_key = self.keys[key] = Key(self, key)
+        return new_key
 
     def delete_key(self, key):
         del self.keys[key]
-
-    def list(self, prefix, delimiter, headers=None):
-        prefix = prefix or ''
-        Key = namedtuple('Key', ['name'])
-        return [Key(key) for key in self.keys if key.startswith(prefix)]
-
-    def initiate_multipart_upload(self, key, headers=None):
-        return Multi(self, key, headers)
 
 
 class Key(object):
     '''S3 key'''
     def __init__(self, bucket, key):
         self.data = ''
-        self.headers = {}
         self.bucket = bucket
         self.key = key
 
-    @property
-    def size(self):
-        return len(self.data)
-
-    def set_contents_from_string(self, data, headers=None):
-        self.data = data
-        self.header = headers or dict()
-
-    def get_contents_to_file(self, fobj, headers=None):
+    def download_fileobj(self, fobj, Config, ExtraArgs=None):
         fobj.write(self.data)
 
-    def delete(self, headers=None):
+    def upload_fileobj(self, fobj, Config, ExtraArgs=None):
+        self.data = fobj.read()
+
+    def delete(self):
         self.bucket.delete_key(self.key)
-
-
-class Multi(object):
-    '''Multipart upload.'''
-    def __init__(self, bucket, key, headers=None):
-        self.bucket = bucket
-        self.key = key
-        self.headers = headers or {}
-        self.parts = {}
-
-    def upload_part_from_file(self, fobj, count):
-        self.parts[count] = fobj.read()
-
-    def complete_upload(self):
-        # Join data together in sorted order. And yes, we can skip indexes
-        data = ''.join(v for _, v in sorted(self.parts.items()))
-        self.bucket.new_key(self.key).set_contents_from_string(data, self.headers)

--- a/test/test_backends/test_swift.py
+++ b/test/test_backends/test_swift.py
@@ -4,7 +4,8 @@ from cStringIO import StringIO
 from swiftclient.exceptions import ClientException
 
 import mock
-from base import BaseTest
+
+from test.base import BaseTest
 
 from s3po.backends.swift import Swift
 from s3po.exceptions import UploadException, DownloadException, DeleteException

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,6 +1,6 @@
 '''Test our Connection'''
 
-from base import BaseTest
+from test.base import BaseTest
 from cStringIO import StringIO
 
 from s3po.exceptions import DownloadException, DeleteException


### PR DESCRIPTION
Much of what s3po handles appears to now be core behavior in boto3, so that's why there's so much code removed. This is the replacement for #32.