### PR TITLE
Account for bytes in Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ test:
 	rm -f .coverage
 	nosetests --rednose --exe --cover-package=s3po --with-coverage --cover-branches --logging-clear-handlers -v
 
+test3:
+	rm -f .coverage
+	python3 -m nose --rednose --exe --cover-package=s3po --with-coverage --cover-branches --logging-clear-handlers -v
+
 clean:
 	# Remove the build
 	rm -rf build dist

--- a/README.md
+++ b/README.md
@@ -140,4 +140,5 @@ vagrant ssh
 
 # On the vagrant instance
 make test
+make test3 # To run the tests under Python 3
 ```

--- a/s3po/backends/memory.py
+++ b/s3po/backends/memory.py
@@ -14,6 +14,13 @@ class Memory(object):
     def download(self, bucket, key, fobj, retries, headers=None):
         '''Download the contents of bucket/key to fobj'''
         obj = self.buckets[bucket].get(key)
+
+        # if we stored a bytes object, decode it into a string
+        try:
+            obj = obj.decode('ascii')
+        except AttributeError:
+            pass
+
         if not obj:
             raise DownloadException('%s / %s not found' % (bucket, key))
         else:

--- a/s3po/connection.py
+++ b/s3po/connection.py
@@ -66,7 +66,7 @@ class Connection(object):
         '''Upload the file at path to bucket/key. This method is important for
         use in batch mode, so that the file object can be used with the right
         context management'''
-        with open(os.path.abspath(path)) as fobj:
+        with open(os.path.abspath(path), 'rb') as fobj:
             return self.upload(
                 bucket, key, fobj,
                 headers=headers, extra=extra, retries=retries)

--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-sudo apt-get install -y python-pip python-dev
+sudo apt-get update
+sudo apt-get install -y python-pip python-dev python3-pip python3-dev
 
 echo '[Credentials]
 aws_access_key_id = not-a-real-id
@@ -11,6 +12,7 @@ aws_secret_access_key = not-a-real-key' > ~/.boto
 (
     cd /vagrant
     sudo pip install -r requirements.txt
+    sudo pip3 install -r requirements.txt
 )
 
 echo $'\ncd /vagrant' >> ~/.profile


### PR DESCRIPTION
This accounts (somewhat) for the difference between bytes and strings in Python 3. It fixes #38 in particular. 

It also adds python 3 to the Vagrant VM for developers and defines a `make test3` target for running the tests specifically under that python 3.